### PR TITLE
Vagrantfile: Add '--links' argument to rsync command

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -173,7 +173,7 @@ Vagrant.configure(2) do |config|
 
       cfg.vm.provider "libvirt" do |lv, override|
         override.vm.box = lvBoxURL
-        override.vm.synced_folder '.', '/vagrant', type: 'rsync'
+        override.vm.synced_folder '.', '/vagrant', type: 'rsync', rsync__args: ["--verbose", "--archive", "--delete"]
         lv.memory = info[:mem]
         lv.cpus = info[:cpus]
         lvAttachDisks( numberOf["disks"][:value], lv )


### PR DESCRIPTION
The default arguments to rsync in Vagrant are "--verbose --archive --delete -z
--copy-links". With the current ceph-ansible directory structure this is
problematic as the symlink ceph.ceph-common ends up being copied as a
directory, thus creating multiple copies of the files beneath it. We modify one
copy of the file but ceph-ansible refers to the file via its symlink and
therefore gets the unmodified copy. Replacing '--copy-links' with '--links'
should resolve this.

Signed-off-by: Brad Hubbard bhubbard@redhat.com
